### PR TITLE
Add "per commit" CI pipeline

### DIFF
--- a/.github/workflows/per-commit_publish-image.yaml
+++ b/.github/workflows/per-commit_publish-image.yaml
@@ -1,6 +1,9 @@
-name: "Update docker images"
+name: "Update docker images (per commit)"
 on:
   workflow_dispatch:
+  push:
+    branches-ignore:
+      - main
   schedule:
     - cron: "41 9 * * *"
 
@@ -18,8 +21,8 @@ jobs:
       - name: "Pull from Docker Hub and republish on Quay.io"
         run: |
           docker pull caddy:2-alpine
-          docker tag caddy:2-alpine ${{ vars.CI_REGISTRY_IMAGE }}:v2-alpine
-          docker push ${{ vars.CI_REGISTRY_IMAGE }}:v2-alpine
+          docker tag caddy:2-alpine ${{ vars.CI_REGISTRY_IMAGE }}:${{ github.sha }}_v2-alpine
+          docker push ${{ vars.CI_REGISTRY_IMAGE }}:${{ github.sha }}_v2-alpine
   # Build a customer Caddy docker image with Cloudflare DNS support and push it to Quay.io
   v2-alpine_cloudflare:
     runs-on: ubuntu-latest
@@ -35,4 +38,4 @@ jobs:
         with:
           file: images/v2-alpine_cloudflare/Dockerfile
           push: true
-          tags: ${{ vars.CI_REGISTRY_IMAGE }}:v2-alpine_cloudflare
+          tags: ${{ vars.CI_REGISTRY_IMAGE }}:${{ github.sha }}_v2-alpine_cloudflare

--- a/.github/workflows/production_publish-image.yaml
+++ b/.github/workflows/production_publish-image.yaml
@@ -1,0 +1,43 @@
+name: "Update docker images (production)"
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: "41 9 * * *"
+
+jobs:
+  # Republish the default caddy:2-alpine docker image on Quay.io
+  v2-alpine:
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: "Login to ${{ vars.CI_REGISTRY }}"
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.CI_REGISTRY }}
+          username: ${{ secrets.CI_REGISTRY_USER }}
+          password: ${{ secrets.CI_REGISTRY_PASSWORD }}
+      - name: "Pull from Docker Hub and republish on Quay.io"
+        run: |
+          docker pull caddy:2-alpine
+          docker tag caddy:2-alpine ${{ vars.CI_REGISTRY_IMAGE }}:v2-alpine
+          docker push ${{ vars.CI_REGISTRY_IMAGE }}:v2-alpine
+  # Build a customer Caddy docker image with Cloudflare DNS support and push it to Quay.io
+  v2-alpine_cloudflare:
+    runs-on: ubuntu-latest
+    environment: Production
+    steps:
+      - name: "Login to ${{ vars.CI_REGISTRY }}"
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.CI_REGISTRY }}
+          username: ${{ secrets.CI_REGISTRY_USER }}
+          password: ${{ secrets.CI_REGISTRY_PASSWORD }}
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          file: images/v2-alpine_cloudflare/Dockerfile
+          push: true
+          tags: ${{ vars.CI_REGISTRY_IMAGE }}:v2-alpine_cloudflare


### PR DESCRIPTION
* Introduce the environment `Production` (branch `main`), only this environment can push to `quay.io/clubdrei/caddy`
* All other branches/environments will build & push a docker image to `quay.io/clubdrei/caddy_per-commit` on every git push