### PR TITLE
[Bugfix] Fixing AbuseIP DB update script to only include valid IPs

### DIFF
--- a/images/v2-alpine_cloudflare_rate-limit/bin/abuseipdb_update.sh
+++ b/images/v2-alpine_cloudflare_rate-limit/bin/abuseipdb_update.sh
@@ -34,6 +34,6 @@ echo "Successfully downloaded the AbuseIPDB blocklist to ${TEMP_DOWNLOAD_FILE}"
 true > "${OUTPUT_FILE}"
 
 # Loop through each IP in the AbuseIPDB file, excluding comments, and add remote_ip before each IP so it can be imported in a Caddyfile
-for IP in $(grep -hv '^#' "${TEMP_DOWNLOAD_FILE}"); do
+grep -Eo '^([0-9]{1,3}\.){3}[0-9]{1,3}' "${TEMP_DOWNLOAD_FILE}" | while read -r IP; do
     echo "remote_ip $IP" >> "${OUTPUT_FILE}"
 done

--- a/images/v2-alpine_rate-limit/bin/abuseipdb_update.sh
+++ b/images/v2-alpine_rate-limit/bin/abuseipdb_update.sh
@@ -34,6 +34,6 @@ echo "Successfully downloaded the AbuseIPDB blocklist to ${TEMP_DOWNLOAD_FILE}"
 true > "${OUTPUT_FILE}"
 
 # Loop through each IP in the AbuseIPDB file, excluding comments, and add remote_ip before each IP so it can be imported in a Caddyfile
-for IP in $(grep -hv '^#' "${TEMP_DOWNLOAD_FILE}"); do
+grep -Eo '^([0-9]{1,3}\.){3}[0-9]{1,3}' "${TEMP_DOWNLOAD_FILE}" | while read -r IP; do
     echo "remote_ip $IP" >> "${OUTPUT_FILE}"
 done


### PR DESCRIPTION
The used IP DB list now contains per line comments which breaks the Caddy configuration.

E.g.: 
```
1.0.87.120       # JP  AS18144   Enecom,Inc.
1.0.211.179      # TH  AS23969   TOT Public Company Limited
1.0.211.200      # TH  AS23969   TOT Public Company Limited
1.2.188.61       # TH  AS23969   TOT Public Company Limited
```
results in 

```
remote_ip 1.0.87.120
remote_ip #
remote_ip JP
remote_ip AS18144
remote_ip Enecom,Inc.
remote_ip 1.0.211.179
remote_ip #
remote_ip TH
remote_ip AS23969
remote_ip TOT
remote_ip Public
remote_ip Company
remote_ip Limited
remote_ip 1.0.211.200
[...]
```

This MR fixes the issue by doing a simple regex check on 4 times 3 numbers separated by a dot.