### PR TITLE
Revert workaround for ClouDNS build

### DIFF
--- a/images/v2-alpine_cloudns/Dockerfile
+++ b/images/v2-alpine_cloudns/Dockerfile
@@ -1,6 +1,5 @@
 FROM caddy:2-builder-alpine AS builder
-# Use custom version of libdns/cloudns: https://github.com/caddy-dns/cloudns/issues/1#issuecomment-2892861238
-RUN xcaddy build --with github.com/caddy-dns/cloudns --replace github.com/libdns/cloudns=github.com/worr/cloudns@8b0aa5e
+RUN xcaddy build --with github.com/caddy-dns/cloudns
 
 FROM caddy:2-alpine
 COPY --from=builder /usr/bin/caddy /usr/bin/caddy


### PR DESCRIPTION
The issue was fixed in https://github.com/caddy-dns/cloudns/issues/1, so we don't need the workaround anymore